### PR TITLE
updating packagedescription to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
error: 'v12' is unavailable    .macOS(.v12), packageDescription.SupportedPlatform:15:27: note: 'v12' was introduced in PackageDescription 5.5